### PR TITLE
Do not copy directory symlinks recursively.

### DIFF
--- a/src/helpers/filesystem.cpp
+++ b/src/helpers/filesystem.cpp
@@ -7,7 +7,7 @@ void helpers::copy_directory(const fs::path &src, const fs::path &dest)
 		if (!fs::exists(src)) {
 			throw filesystem_exception(
 				"helpers::copy_directory: Source directory does not exist '" + src.string() + "'");
-		} else if (!fs::is_directory(src)) {
+		} else if (!fs::is_directory(fs::symlink_status(src))) {
 			throw filesystem_exception(
 				"helpers::copy_directory: Source directory is not a directory '" + src.string() + "'");
 		} else if (!fs::exists(dest) && !fs::create_directories(dest)) {
@@ -17,7 +17,7 @@ void helpers::copy_directory(const fs::path &src, const fs::path &dest)
 
 		fs::directory_iterator endit;
 		for (fs::directory_iterator it(src); it != endit; ++it) {
-			if (fs::is_directory(it->status())) {
+			if (fs::is_directory(it->symlink_status())) {
 				helpers::copy_directory(it->path(), dest / it->path().filename());
 			} else {
 				fs::copy(it->path(), dest / it->path().filename());

--- a/src/tasks/internal/cp_task.cpp
+++ b/src/tasks/internal/cp_task.cpp
@@ -44,7 +44,7 @@ std::shared_ptr<task_results> cp_task::run()
 	for (fs::directory_iterator item(base_dir); item != end_itr; ++item) {
 		if (regex_match(item->path().filename().string(), pattern)) {
 			auto target = output_is_dir ? (output / item->path().filename()) : output;
-			if (fs::is_directory(item->path())) {
+			if (fs::is_directory(fs::symlink_status(item->path()))) {
 				helpers::copy_directory(item->path(), target);
 			} else {
 				boost::system::error_code error_code;


### PR DESCRIPTION
When copying files (running the `cp` task, or moving files from/to sandbox), symlinks to directories are followed. The target of the symlink is copied. The resolution and copying happens outside of the sandbox.

By creating a directory containing a nonempty file and a few symlinks to the directory itself, this can be abused for a DoS attack against the worker, filling all allowed space on the disk containing the working directory. After the copying fails due to full disk, the files are not cleaned up.

Moreover, if a compiler could be persuaded to create a symlink, some directories outside of the sandbox could be copied into the execution sandbox, making it readable to the evaluated program.

Fixed this by replacing `is_directory(const path&)` (equivalent to `is_directory(status(const path&))`) with `is_directory(symlink_status(const path&))`. `symlink_status` is identical to `status`, except that if the path refers to a symbolic link, it obtains information about the link itself, not the target.