### PR TITLE
Fix use-after-free in isolate_sandbox.cpp

### DIFF
--- a/src/sandbox/isolate_sandbox.cpp
+++ b/src/sandbox/isolate_sandbox.cpp
@@ -173,6 +173,8 @@ void isolate_sandbox::isolate_init_child(int fd_0, int fd_1)
 	execvp(isolate_binary_.c_str(), const_cast<char **>(args));
 
 	// Never reached
+	free(const_cast<char *>(args[2]));
+
 	log_and_throw(logger_, "Exec returned to child: ", strerror(errno));
 }
 
@@ -205,6 +207,8 @@ void isolate_sandbox::isolate_cleanup()
 		execvp(isolate_binary_.c_str(), const_cast<char **>(args));
 
 		// Never reached
+		free(const_cast<char *>(args[2]));
+
 		log_and_throw(logger_, "Exec returned to child: ", strerror(errno));
 		break;
 	default:
@@ -246,6 +250,9 @@ void isolate_sandbox::isolate_run(const std::string &binary, const std::vector<s
 		execvp(isolate_binary_.c_str(), args);
 
 		// Never reached
+		for(char **arg = args; *arg; arg++)
+			free(*arg);
+
 		log_and_throw(logger_, "Exec returned to child: ", strerror(errno));
 	} break;
 	default: {

--- a/src/sandbox/isolate_sandbox.cpp
+++ b/src/sandbox/isolate_sandbox.cpp
@@ -250,8 +250,8 @@ void isolate_sandbox::isolate_run(const std::string &binary, const std::vector<s
 		execvp(isolate_binary_.c_str(), args);
 
 		// Never reached
-		for(char **arg = args; *arg; arg++)
-			free(*arg);
+		for(char **arg = args; *arg; arg++) { free(*arg); }
+		delete[] args;
 
 		log_and_throw(logger_, "Exec returned to child: ", strerror(errno));
 	} break;

--- a/src/sandbox/isolate_sandbox.cpp
+++ b/src/sandbox/isolate_sandbox.cpp
@@ -165,7 +165,7 @@ void isolate_sandbox::isolate_init_child(int fd_0, int fd_1)
 
 	args[0] = isolate_binary_.c_str();
 	args[1] = "--cg";
-	args[2] = ("--box-id=" + std::to_string(id_)).c_str();
+	args[2] = strdup(("--box-id=" + std::to_string(id_)).c_str());
 	args[3] = "--init";
 	args[4] = NULL;
 
@@ -198,7 +198,7 @@ void isolate_sandbox::isolate_cleanup()
 		const char *args[5];
 		args[0] = isolate_binary_.c_str();
 		args[1] = "--cg";
-		args[2] = ("--box-id=" + std::to_string(id_)).c_str();
+		args[2] = strdup(("--box-id=" + std::to_string(id_)).c_str());
 		args[3] = "--cleanup";
 		args[4] = NULL;
 		// const_cast is ugly, but this is working with C code - execv does not modify its arguments


### PR DESCRIPTION
The pointer returned by `(A + B).c_str()` must not be dereferenced after the full expression ends, because the result of `(A + B)` is destroyed. Here, it does not manifest probably because no more memory is allocated before `execve` to overwrite the deallocated object. It could in case of short string optimization.

Wrapped it in `strdup` call as is already done elsewhere in the file.