### PR TITLE
Exit codes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.11.0)
 project(recodex-worker)
-set(RECODEX_VERSION 1.8.0)
+set(RECODEX_VERSION 1.9.0)
 enable_testing()
 
 set(EXEC_NAME ${PROJECT_NAME})

--- a/examples/job-config.yml
+++ b/examples/job-config.yml
@@ -25,7 +25,7 @@ tasks:
         args:
             - "/tmp/main.c"
             - "/tmp/hello_from_codex_worker/main.c"
-    - task-id: "eval_test01"
+    - task-id: "compile_test01"
       priority: 3
       fatal-failure: false
       dependencies:
@@ -54,8 +54,32 @@ tasks:
                 - src: /tmp/hello_from_codex_worker
                   dst: "evaluate"
                   mode: RW
-    - task-id: "remove_created_dir"
+    - task-id: "run_test01"
       priority: 4
+      fatal-failure: false
+      dependencies:
+        - "compile_test01"
+      cmd:
+        bin: "./test"
+        args: []
+        success_exit_codes: # list of exit codes which will be accepted as success
+          - 0  # zero is success by default, but if success_exit_codes is present, it must be added explicitly.
+          - 1  # single code
+          - [100, 200]  # an interval (inclusive)
+          # codes 0, 1, 100, 101, ... 199, and 200 will all be accepted
+      sandbox:
+        name: "isolate"
+        limits:
+            - hw-group-id: "group1"  # determines specific limits for specific machines
+              time: 1  # seconds
+              wall-time: 1  # seconds
+              extra-time: 1  # seconds
+              parallel: 0  # time and memory limits are merged from all potential processes/threads
+              environ-variable:
+                ISOLATE_BOX: "/box"
+                PATH: "/usr/bin"
+    - task-id: "remove_created_dir"
+      priority: 5
       fatal-failure: false
       cmd:
           bin: "rm"

--- a/examples/job-config.yml
+++ b/examples/job-config.yml
@@ -62,8 +62,8 @@ tasks:
       cmd:
         bin: "./test"
         args: []
-        success_exit_codes: # list of exit codes which will be accepted as success
-          - 0  # zero is success by default, but if success_exit_codes is present, it must be added explicitly.
+        success-exit-codes: # list of exit codes which will be accepted as success
+          - 0  # zero is success by default, but if success-exit-codes is present, it must be added explicitly.
           - 1  # single code
           - [100, 200]  # an interval (inclusive)
           # codes 0, 1, 100, 101, ... 199, and 200 will all be accepted

--- a/src/config/task_metadata.h
+++ b/src/config/task_metadata.h
@@ -37,7 +37,7 @@ public:
 		std::shared_ptr<sandbox_config> sandbox = nullptr,
 		std::string test_id = "")
 		: task_id(task_id), priority(priority), dependencies(deps), test_id(test_id), type(type), fatal_failure(fatal),
-		  binary(cmd), cmd_args(args), sandbox(sandbox)
+		  binary(cmd), cmd_args(args), success_exit_codes({true}), sandbox(sandbox)
 	{
 	}
 
@@ -59,6 +59,20 @@ public:
 	std::string binary;
 	/** Arguments for executed command. */
 	std::vector<std::string> cmd_args;
+	/**
+	 * List of command exit codes which should be treated as "success" (denoted by true value at their index).
+	 * By default, the list has only one item - true at index 0.
+	 */
+	std::vector<bool> success_exit_codes;
+
+	/**
+	 * Safely checks whether given exit code is deemed successful (handling corner cases).
+	 */
+	bool is_success_exit_code(int code) const
+	{
+		// indices outside success_exit_codes range are handled as false
+		return code >= 0 && ((std::size_t) code) < success_exit_codes.size() && success_exit_codes[code];
+	}
 
 	/** If not null than this task is external and will be executed in given sandbox. */
 	std::shared_ptr<sandbox_config> sandbox;

--- a/src/config/task_results.h
+++ b/src/config/task_results.h
@@ -7,7 +7,13 @@
 /**
  * Return error codes of sandbox. Code names corresponds isolate's meta file error codes.
  */
-enum class isolate_status { OK, RE, SG, TO, XX };
+enum class isolate_status {
+	OK,
+	RE, // run-time error, i.e., exited with a non-zero exit code
+	SG, // program died on a signal
+	TO, // timed out
+	XX, // internal error of the sandbox
+};
 
 /**
  * Status of whole task after execution.

--- a/src/helpers/config.cpp
+++ b/src/helpers/config.cpp
@@ -46,7 +46,7 @@ void load_task_success_exit_codes(const YAML::Node &node, std::vector<bool> &suc
 			}
 		}
 	} else {
-		throw helpers::config_exception("Task command success_exit_codes must be an integer or a list.");
+		throw helpers::config_exception("Task command success-exit-codes must be an integer or a list.");
 	}
 }
 
@@ -125,8 +125,8 @@ std::shared_ptr<job_metadata> helpers::build_job_metadata(const YAML::Node &conf
 						task_meta->cmd_args = ctask["cmd"]["args"].as<std::vector<std::string>>();
 					} // can be omitted... no throw
 
-					if (ctask["cmd"]["success_exit_codes"]) {
-						load_task_success_exit_codes(ctask["cmd"]["success_exit_codes"], task_meta->success_exit_codes);
+					if (ctask["cmd"]["success-exit-codes"]) {
+						load_task_success_exit_codes(ctask["cmd"]["success-exit-codes"], task_meta->success_exit_codes);
 					}
 				} else {
 					throw config_exception("Command in task is not a map");

--- a/src/tasks/external_task.h
+++ b/src/tasks/external_task.h
@@ -75,16 +75,25 @@ private:
 	void make_binary_executable(const std::string &binary);
 
 	/**
+	 * A task may accept different exit codes (than 0) as success. However, sandbox results may indicated nonzero exit
+	 * codes as failures. This method fixes such situations.
+	 */
+	void postprocess_exit_codes(std::shared_ptr<task_results> result);
+
+	/**
 	 * Initialize output if requested.
 	 */
 	void results_output_init();
+
 	/**
 	 * Get configuration limited content of the stdout and stderr and return it.
 	 * @param result to which stdout and err will be assigned
 	 */
 	void get_results_output(std::shared_ptr<task_results> result);
+
 	void process_results_output(
 		const std::shared_ptr<task_results> &result, const fs::path &stdout_path, const fs::path &stderr_path);
+
 	void process_carboncopy_output(const fs::path &stdout_path, const fs::path &stderr_path);
 
 	/** Worker default configuration */

--- a/tests/job_config.cpp
+++ b/tests/job_config.cpp
@@ -192,6 +192,14 @@ TEST(job_config_test, config_data)
 						   "          args:\n"
 						   "              - -v\n"
 						   "              - \"-f 01.in\"\n"
+						   "          success_exit_codes:\n"
+						   "              - 1\n"
+						   "              - [3,5]\n"
+						   "              - [10,12]\n"
+						   "              - [11,14]\n"
+						   "              - [21,23]\n"
+						   "              - [22,24]\n"
+						   "              - [20,25]\n"
 						   "      sandbox:\n"
 						   "          name: fake\n"
 						   "          stdin: 01.in\n"
@@ -250,6 +258,14 @@ TEST(job_config_test, config_data)
 	ASSERT_EQ(task2->binary, "recodex");
 	ASSERT_EQ(task2->cmd_args[0], "-v");
 	ASSERT_EQ(task2->cmd_args[1], "-f 01.in");
+
+	std::vector<int> codes{1, 3, 4, 5, 10, 11, 12, 13, 14, 20, 21, 22, 23, 24, 25};
+	for (auto code : codes) { ASSERT_TRUE(task2->is_success_exit_code(code)); }
+	std::size_t false_count = 0;
+	for (int i = 0; i < 256; ++i) {
+		if (!task2->is_success_exit_code(i)) { ++false_count; }
+	}
+	ASSERT_EQ(false_count, 256 - codes.size());
 
 	ASSERT_NE(task2->sandbox, nullptr);
 	ASSERT_EQ(task2->sandbox->name, "fake");

--- a/tests/job_config.cpp
+++ b/tests/job_config.cpp
@@ -192,7 +192,7 @@ TEST(job_config_test, config_data)
 						   "          args:\n"
 						   "              - -v\n"
 						   "              - \"-f 01.in\"\n"
-						   "          success_exit_codes:\n"
+						   "          success-exit-codes:\n"
 						   "              - 1\n"
 						   "              - [3,5]\n"
 						   "              - [10,12]\n"


### PR DESCRIPTION
Adding configuration to allow non-zero exit codes of external exec tasks (in a sandbox) to be treated as successful executions (some tests actually expect the tested solution to return non-zero exit code).